### PR TITLE
Allow iframe mounting from mjftw.dev and fix redirect loops

### DIFF
--- a/lib/tetrex_web/plugs/require_username.ex
+++ b/lib/tetrex_web/plugs/require_username.ex
@@ -12,7 +12,13 @@ defmodule TetrexWeb.Plugs.RequireUsername do
 
     signup_path = ~p"/signup"
 
-    if conn.request_path == signup_path do
+    # Skip redirect for iframe contexts to prevent redirect loops
+    is_iframe = case get_req_header(conn, "sec-fetch-dest") do
+      ["iframe"] -> true
+      _ -> false
+    end
+
+    if conn.request_path == signup_path or is_iframe do
       conn
     else
       case UserStore.get_user(user_id) do


### PR DESCRIPTION
- Configure CSP frame-ancestors and X-Frame-Options to allow iframe from mjftw.dev
- Skip username requirement redirects for iframe requests to prevent infinite loops