### PR TITLE
Remove signup page and fix iframe session persistence

### DIFF
--- a/lib/tetrex_web/endpoint.ex
+++ b/lib/tetrex_web/endpoint.ex
@@ -8,7 +8,8 @@ defmodule TetrexWeb.Endpoint do
     store: :cookie,
     key: "_tetrex_key",
     signing_salt: "BRy6Zu+s",
-    same_site: "Lax"
+    same_site: "None",
+    secure: true
   ]
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]


### PR DESCRIPTION
- Remove signup page, RequireUsername plug, and related redirects
- Move username generation to lobby for users without names
- Fix session cookies for iframe contexts with SameSite=None and secure=true
- This prevents username cycling in iframe due to blocked cookies

Amp-Thread: https://ampcode.com/threads/T-a5e9ec73-9a23-4daf-870e-7b373ad363d5