### PR TITLE
Use Elixir 1.18.4, OTP 28.0.1, and Debian bookworm-20250630-slim

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -16,9 +16,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.14.1-erlang-25.1-debian-bullseye-20220801-slim
 #
-ARG ELIXIR_VERSION=1.14.1
-ARG OTP_VERSION=25.1
-ARG DEBIAN_VERSION=bullseye-20220801-slim
+ARG ELIXIR_VERSION=1.18.4
+ARG OTP_VERSION=28.0.1
+ARG DEBIAN_VERSION=bookworm-20250630-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
Updates the Docker elixir base image with new versions.
Use Elixir 1.18.4, OTP 28.0.1, and Debian bookworm-20250630-slim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying platform versions to use newer releases for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->